### PR TITLE
Adicionando Objeto não localizado no del_routine

### DIFF
--- a/del_routine.py
+++ b/del_routine.py
@@ -63,4 +63,6 @@ if __name__ == '__main__':
         if 'Aguardando recebimento pela ECT.' in old_state:
             if time_dif > int_del:
                 del_user(elem['code'])
-
+        if 'Objeto não localizado no fluxo postal.' in old_state:
+            if time_dif > int_del:
+                del_user(elem['code'])


### PR DESCRIPTION
Olá GabrielRF !

Olhei rapidamente o código e observei que faltava esse caso:
Objeto não localizado no fluxo postal.
Os objetos perdidos recebem esse _status_.
Um exemplo de objeto com esse _status_ : RM768260759CN

Agradeço pelo ótimo bot feito 👍 !
Abraço !