### PR TITLE
Ordenar pacotes cadastrados

### DIFF
--- a/check_update.py
+++ b/check_update.py
@@ -3,7 +3,7 @@ import json
 import requests
 import re
 from bs4 import BeautifulSoup
-from datetime import date
+from datetime import date, datetime
 
 config = configparser.ConfigParser()
 config.sections()
@@ -18,6 +18,7 @@ def check_update(code, max_retries=3):
     if not (re.search(regexp, code)):
         return 2
     stats = []
+    data_postagem = ''
     try:
         request_xml = '''
             <rastroObjeto>
@@ -55,6 +56,8 @@ def check_update(code, max_retries=3):
         return 1
     stats.append(str(u'\U0001F4EE') + ' <b>' + code + '</b>')
     for evento in reversed(tabela):
+        if 'postagem' in evento.keys() and evento.get('postagem', {}).get('datapostagem'):
+            data_postagem = datetime.strptime(evento.get('postagem').get('datapostagem'), '%d/%m/%Y %H:%M:%S')
         try:
             dia0 = int(tabela[len(tabela)-1]['data'].split('/')[0])
             mes0 = int(tabela[len(tabela)-1]['data'].split('/')[1])
@@ -108,4 +111,4 @@ def check_update(code, max_retries=3):
             if 'liberado sem' in observacao.lower():
                 mensagem = mensagem + ' ' + str(u'\U0001F389')
         stats.append(mensagem)
-    return stats
+    return stats, data_postagem

--- a/check_update.py
+++ b/check_update.py
@@ -56,6 +56,7 @@ def check_update(code, max_retries=3):
         return 1
     stats.append(str(u'\U0001F4EE') + ' <b>' + code + '</b>')
     for evento in reversed(tabela):
+        # extract string post date and make a cast to datetime
         if 'postagem' in evento.keys() and evento.get('postagem', {}).get('datapostagem'):
             data_postagem = datetime.strptime(evento.get('postagem').get('datapostagem'), '%d/%m/%Y %H:%M:%S')
         try:

--- a/data_postagem_migration.py
+++ b/data_postagem_migration.py
@@ -1,0 +1,41 @@
+from pymongo import MongoClient
+import re
+from datetime import datetime
+
+client = MongoClient()
+db = client.rastreiobot
+
+
+def get_data_postagem(stat):
+    for mensagem in stat:
+        if 'postado' in mensagem:
+            data_regex = re.compile(r'Data: ([\d]{2}\/[\d]{2}\/[\d]{4} [\d]{2}\:[\d]{2})')
+            try:
+                data_postagem = data_regex.match(mensagem).group(1)
+            except AttributeError:
+                data_postagem = ''
+            return data_postagem
+
+
+def migrate():
+    print('Iniciando migração')
+    todos_pacotes = list(db.rastreiobot.find({'data_postagem': {'$exists': False}}))
+    count = 1
+    pacotes_migrados = 0
+    for pacote in todos_pacotes:
+        print('Migrando pacote %d de %d' % (count, len(todos_pacotes)))
+        count += 1
+
+        pacote_stats = pacote.get('stat', [])
+        data_postagem_str = get_data_postagem(pacote_stats)
+        if data_postagem_str:
+            data_postagem = datetime.strptime(data_postagem_str, '%d/%m/%Y %H:%M')
+            db.rastreiobot.update_one({'_id': pacote['_id']}, {'$set': {'data_postagem': data_postagem}})
+            pacotes_migrados += 1
+    return pacotes_migrados
+
+
+if __name__ == '__main__':
+    pacotes_migrados = migrate()
+    print('Migração finalizada!')
+    print('%d pacotes atualizados.' % pacotes_migrados)

--- a/rastreiobot.py
+++ b/rastreiobot.py
@@ -60,13 +60,25 @@ def count_packages():
 
 
 def sort_alpha(chatid):
+    '''
+    Retrieves a user packages in alphabetical order
+
+    Args:
+        chatid (int): user/chat id
+
+    Returns:
+        Mongodb cursor: packages in alphabetical order
+    '''
     chat = str(chatid)
+
+    # query user packages and sort them in alphabetical order using the user description
     packages = db.rastreiobot.find({'users': chat}).sort(chat, ASCENDING)
     return packages
 
 ## List packages of a user
 def list_packages(chatid, done, alfa=False):
     try:
+        # "alfa" parameter sort the packages in alphabetical order by description
         if alfa:
             cursor = sort_alpha(chatid)
         else:
@@ -339,6 +351,7 @@ def echo_all(message):
         , parse_mode='HTML')
 
 
+# Query packages and sort in alphabetical order
 @bot.message_handler(commands=['pacotesalfa', 'PacotesAlfa', 'Pacotesalfa', 'pacotesAlfa'])
 def echo_all(message):
     bot.send_chat_action(message.chat.id, 'typing')
@@ -360,6 +373,7 @@ def echo_all(message):
     bot.send_message(chatid, message, parse_mode='HTML', reply_markup=markup_clean)
 
 
+# Query done packages and sort in alphabetical order
 @bot.message_handler(commands=['concluidosalfa', 'ConcluidosAlfa', 'Concluidosalfa', 'concluidosAlfa'])
 def echo_all(message):
     bot.send_chat_action(message.chat.id, 'typing')

--- a/rastreiobot.py
+++ b/rastreiobot.py
@@ -35,7 +35,7 @@ client = MongoClient()
 db = client.rastreiobot
 
 markup_btn = types.ReplyKeyboardMarkup(resize_keyboard=True)
-markup_btn.row('/Pacotes','/Info','/Concluidos', '/ConcluidosAlfa')
+markup_btn.row('/Pacotes','/Info','/Concluidos')
 markup_clean = types.ReplyKeyboardRemove(selective=False)
 
 ## Check if package exists in DB
@@ -337,6 +337,27 @@ def echo_all(message):
             'Envie <code>/del código do pacote</code> para excluir o pacote de sua lista.'
             '\n\n<code>/del PN123456789CD</code>'
         , parse_mode='HTML')
+
+
+@bot.message_handler(commands=['pacotesalfa', 'PacotesAlfa', 'Pacotesalfa', 'pacotesAlfa'])
+def echo_all(message):
+    bot.send_chat_action(message.chat.id, 'typing')
+    chatid = message.chat.id
+    message, qtd = list_packages(chatid, done=False, alfa=True)
+
+    if qtd == 0:
+        message = 'Nenhum pacote encontrado.'
+    elif qtd == -1:
+        message = 'Ops!\nHouve um problema com o bot.\nTente novamente mais tarde.'
+    else:
+        message = '<b>Clique para ver o histórico:</b>\n' + message
+    if qtd > 7 and str(chatid) not in PATREON:
+        message = (
+            message + '\n'
+            + str(u'\U0001F4B5') + '<b>Colabore!</b>'
+            + '\nhttp://grf.xyz/paypal'
+        )
+    bot.send_message(chatid, message, parse_mode='HTML', reply_markup=markup_clean)
 
 
 @bot.message_handler(commands=['concluidosalfa', 'ConcluidosAlfa', 'Concluidosalfa', 'concluidosAlfa'])

--- a/rastreiobot.py
+++ b/rastreiobot.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 from check_update import check_update
 from datetime import datetime, timedelta
 from time import time
-from pymongo import MongoClient
+from pymongo import MongoClient, ASCENDING
 from telebot import types
 
 import configparser
@@ -61,7 +61,7 @@ def count_packages():
 ## List packages of a user
 def list_packages(chatid, done):
     try:
-        cursor = db.rastreiobot.find()
+        cursor = db.rastreiobot.find().sort('data_postagem', ASCENDING)
         aux = ''
         qtd = 0
         for elem in cursor:
@@ -119,7 +119,7 @@ def check_user(code, user):
 ## Insert package on DB
 def add_package(code, user):
     # import ipdb; ipdb.set_trace()
-    stat = get_update(code)
+    stat, data_postagem = get_update(code)
     if stat == 0:
         return stat
     elif stat == 2:
@@ -140,7 +140,8 @@ def add_package(code, user):
             "code" : code.upper(),
             "users" : [user],
             "stat" : stat,
-            "time" : str(time())
+            "time" : str(time()),
+            "data_postagem": data_postagem
         })
         stat = 10
     return stat

--- a/routine.py
+++ b/routine.py
@@ -33,6 +33,7 @@ db = client.rastreiobot
 multiple = sys.argv[1]
 
 def get_package(code):
+    # ignores the second parameter
     stat, _ = check_update(code)
     if stat == 0:
         stat = 'Sistema dos Correios fora do ar.'

--- a/routine.py
+++ b/routine.py
@@ -33,7 +33,7 @@ db = client.rastreiobot
 multiple = sys.argv[1]
 
 def get_package(code):
-    stat = check_update(code)
+    stat, _ = check_update(code)
     if stat == 0:
         stat = 'Sistema dos Correios fora do ar.'
     elif stat == 1:


### PR DESCRIPTION
Criei uma nova key no banco "data_postagem" pra poder ordenar quando faz a busca pelos pacotes. Os novos pacotes cadastrados já vão ter essa nova key. Para os antigos eu fiz uma migration. O bot vai continuar funcionando mesmo sem rodar a migration, porém os pacotes antigos não serão ordenados pela data de postagem dos correios. Criei a opção de ordenar alfabeticamente com os comandos /PacotesAlfa e /ConcluidosAlfa. A opção de ordenar pela data de postagem está como padrão.