### PR TITLE
Url of Correios in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## About
 
-This is a [Telegram](http://telegram.org) Bot that tracks packages from the [Brazilian Mail Service](www.correios.com.br). It runs on Python 3 and uses MongoDB.
+This is a [Telegram](http://telegram.org) Bot that tracks packages from the [Brazilian Mail Service](https://www.correios.com.br/). It runs on Python 3 and uses MongoDB.
 
 [Try it!](http://telegram.me/RastreioBot)
 


### PR DESCRIPTION
URLs em Markdown tem que ter `http://` ou `https://` (seu protocolo), isso corrigir a URL dos correiros no README.