### PR TITLE
Update Correios get api to accept multiple packages at once

### DIFF
--- a/tests/data/correios-package-in-transit.json
+++ b/tests/data/correios-package-in-transit.json
@@ -1,0 +1,101 @@
+{
+  "versao": "3.0",
+  "quantidade": "1",
+  "pesquisa": "Lista de Objetos",
+  "resultado": "Todos os eventos",
+  "objeto": [
+    {
+      "numero": "AB019345678BR",
+      "sigla": "ON",
+      "nome": "ETIQUETA LOGICA SEDEX",
+      "categoria": "SEDEX",
+      "evento": [
+        {
+          "tipo": "RO",
+          "status": "01",
+          "data": "10/03/2020",
+          "hora": "14:17",
+          "criacao": "10032020141708",
+          "descricao": "Objeto em trânsito - por favor aguarde",
+          "unidade": {
+            "local": "AGF CRUZEIRO SAO PAULO",
+            "codigo": "70650981",
+            "cidade": "SAO PAULO",
+            "uf": "SP",
+            "sto": "00424239",
+            "tipounidade": "Agência dos Correios",
+            "endereco": {
+              "codigo": "335549",
+              "cep": "70650980",
+              "logradouro": "QUADRA SHCES",
+              "complemento": "BLOCO C LOJA 8",
+              "numero": "401",
+              "localidade": "SAO PAULO",
+              "uf": "SP",
+              "bairro": "CRUZEIRO NOVO",
+              "latitude": "-15",
+              "longitude": "-47"
+            }
+          },
+          "destino": [
+            {
+              "local": "CTE SAO PAULO",
+              "codigo": "71906970",
+              "cidade": "SAO PAULO",
+              "bairro": "ZONA INDUSTRIAL (GUARA)",
+              "uf": "SP",
+              "endereco": {
+                "codigo": "24157",
+                "cep": "71925971",
+                "logradouro": "TRECHO STRC",
+                "complemento": "CONJUNTO A LOTES 1 E 2",
+                "numero": "2",
+                "localidade": "SAO PAULO",
+                "uf": "SP",
+                "bairro": "ZONA INDUSTRIAL (GUARA)",
+                "latitude": "-15",
+                "longitude": "-47"
+              }
+            }
+          ],
+          "cepDestino": "51020260",
+          "prazoGuarda": "0",
+          "diasUteis": "0",
+          "dataPostagem": "10/03/2020"
+        },
+        {
+          "tipo": "PO",
+          "status": "01",
+          "data": "10/03/2020",
+          "hora": "14:01",
+          "criacao": "10032020140102",
+          "descricao": "Objeto postado",
+          "unidade": {
+            "local": "AGF CRUZEIRO SAO PAULO",
+            "codigo": "70650981",
+            "cidade": "SAO PAULO",
+            "uf": "SP",
+            "sto": "00424239",
+            "tipounidade": "Agência dos Correios",
+            "endereco": {
+              "codigo": "335549",
+              "cep": "70650980",
+              "logradouro": "QUADRA SHCES",
+              "complemento": "BLOCO C LOJA 8",
+              "numero": "401",
+              "localidade": "SAO PAULO",
+              "uf": "SP",
+              "bairro": "CRUZEIRO NOVO",
+              "latitude": "-15",
+              "longitude": "-47"
+            }
+          },
+          "cepDestino": "51020260",
+          "prazoGuarda": "0",
+          "diasUteis": "0",
+          "dataPostagem": "10/03/2020"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_api_correios.py
+++ b/tests/test_api_correios.py
@@ -1,0 +1,85 @@
+import json
+from unittest.mock import Mock, call, patch
+
+from apis.apicorreios import (
+    parse,
+    parse_multiple_codes_output,
+    parse_single_code_output,
+)
+
+
+
+@patch("apis.apicorreios.parse")
+def test_parse_single_code_output(mocked_parse):
+    stats = ["stats"]
+    mocked_parse.return_value = stats
+
+    code = "AB012345678BR"
+    events = []
+    response = {
+        "objeto": [{
+            "evento": events,
+            "numero": code,
+        }],
+    }
+
+    assert parse_single_code_output(response) == stats
+    mocked_parse.assert_called_once_with(code, events)
+
+
+@patch("apis.apicorreios.parse")
+def test_parse_multiple_codes_output(mocked_parse):
+    stats1 = ["stats1"]
+    stats2 = ["stats2"]
+    mocked_parse.side_effect = [stats1, stats2]
+
+    code1 = "AB012345678BR"
+    code2 = "CD012345678BR"
+    events1 = events2 = []
+
+    response = {
+        "objeto": [{
+            "evento": events1,
+            "numero": code1,
+        }, {
+            "evento": events2,
+            "numero": code2,
+        }],
+    }
+
+    assert parse_multiple_codes_output(response) == {
+        code1: stats1,
+        code2: stats2,
+    }
+
+    mocked_parse.assert_has_calls([
+        call(code1, events1),
+        call(code2, events2),
+    ])
+
+
+@patch("apis.apicorreios.db.update_package")
+def test_parse_package_in_transit(mocked_update_package):
+    with open("tests/data/correios-package-in-transit.json") as file:
+        returned_package = json.load(file)
+
+    code = returned_package["objeto"][0]["numero"]
+    events = returned_package["objeto"][0]["evento"]
+
+    events = parse(code, events)
+
+    assert len(events) == 3
+    assert '📮<a href="https://t.me/rastreiobot?start=AB019345678BR">AB019345678BR</a>' == events[0]
+    assert (
+        "Data: 10/03/2020 14:01\n"
+        "Local: Agf Cruzeiro Sao Paulo\n"
+        "Situação: <b>Objeto postado</b> 📦"
+    ) == events[1]
+
+    assert (
+        "Data: 10/03/2020 14:17\n"
+        "Local: Agf Cruzeiro Sao Paulo\n"
+        "Situação: <b>Objeto em trânsito - por favor aguarde</b>\n"
+        "Observação: Cte Sao Paulo"
+    ) == events[2]
+    assert not mocked_update_package.called


### PR DESCRIPTION
- Correios aceita múltiplos pacotes por requisição
- Atualiza função `correios.async_get` para aceitar uma lista de códigos. Nesse caso, retorna `{"código": ["stats"]}`